### PR TITLE
shorter countdown to avoid timeout

### DIFF
--- a/cms/djangoapps/contentstore/signals/handlers.py
+++ b/cms/djangoapps/contentstore/signals/handlers.py
@@ -27,7 +27,7 @@ from .signals import GRADING_POLICY_CHANGED
 
 log = logging.getLogger(__name__)
 
-GRADING_POLICY_COUNTDOWN_SECONDS = 3600
+GRADING_POLICY_COUNTDOWN_SECONDS = 25 * 60  # shorter countdown to avoid time out on rabbitmq
 
 
 def locked(expiry_seconds, key):  # lint-amnesty, pylint: disable=missing-function-docstring


### PR DESCRIPTION
rmq consumer_timeout defaults to 30 mins. Set countdown to 25 mins to avoid unrecoverable error